### PR TITLE
Implemented external commands and background process cleanup function

### DIFF
--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -5,5 +5,6 @@
 #include "command.h"
 
 bool handle_command(Command *cmd);
+void cleanup_zombes();
 
 #endif

--- a/src/mysh.c
+++ b/src/mysh.c
@@ -14,7 +14,13 @@ int main() {
     char *prompt = "mysh> ";
 
     while (true) {
+        cleanup_zombies();
+
+        // ensure prompt outputs properly
+        fflush(stdout);
         printf("%s", prompt);
+        fflush(stdout);
+        
         if (fgets(buffer, sizeof(buffer), stdin) == NULL) break;
 
         char **token_arr = tokenize(buffer);
@@ -24,15 +30,15 @@ int main() {
         if (cmd == NULL) continue;
 
         // debug print
-        printf("Command: %s\nArgs: ", cmd->command);
-        for (int i = 0; cmd->args[i] != NULL; i++) {
-            printf("%s ", cmd->args[i]);
-        }
-        printf("\nInput file: %s\n", cmd->input_file ? cmd->input_file : "");
-        printf("Output file: %s\n", cmd->output_file ? cmd->output_file : "");
-        printf("Append: %s\n", cmd->append ? "true" : "false");
-        printf("Background: %s\n", cmd->background ? "true" : "false");
-        printf("Output:\n");
+        // printf("Command: %s\nArgs: ", cmd->command);
+        // for (int i = 0; cmd->args[i] != NULL; i++) {
+        //     printf("%s ", cmd->args[i]);
+        // }
+        // printf("\nInput file: %s\n", cmd->input_file ? cmd->input_file : "");
+        // printf("Output file: %s\n", cmd->output_file ? cmd->output_file : "");
+        // printf("Append: %s\n", cmd->append ? "true" : "false");
+        // printf("Background: %s\n", cmd->background ? "true" : "false");
+        // printf("Output:\n");
 
         // handle command and check running status
         if (!handle_command(cmd)) {


### PR DESCRIPTION
Additional changes:

- Temporarily disabled all debug prints
- Set background job list to a maximum of 100 but did not yet prevent new background jobs from executing when list is full
- Include buffer checking for outputs before and after printing shell prompt

Affected files: interpreter.c, interpreter.h, mysh.c